### PR TITLE
Enum refactor & migration.

### DIFF
--- a/src/core/include/enum.hpp
+++ b/src/core/include/enum.hpp
@@ -1,0 +1,21 @@
+#ifndef CORE_ENUM_HPP
+#define CORE_ENUM_HPP
+
+// clang-format off
+namespace zclipboard::core {
+    enum class Platform : int {
+        LINUX,
+        MACOS,
+        WINDOWS,
+        UNKNOWN
+    };
+
+    enum class ContentType : int {
+        TEXT,
+        IMAGE,
+        UNKNOWN
+    };
+
+}  // namespace zclipboard::core
+
+#endif  // CORE_ENUM_HPP

--- a/src/zUtils/include/zUtils.hpp
+++ b/src/zUtils/include/zUtils.hpp
@@ -3,22 +3,15 @@
 #include <QString>
 #include <QSystemTrayIcon>
 #include "../../language/include/translate.hpp"
+#include "../../core/include/enum.hpp"
 #include <QWidget>
 #include <QObject>
 #include <QMimeData>
 
+using zclipboard::core::Platform;
 using zclipboard::language::Translate;
 
 namespace zclipboard {
-
-// clang-format off
-enum class ContentType : int {
-    TEXT,
-    IMAGE,
-    UNKNOWN
-};
-// clang-format on
-
 class zUtils : public QObject {
     Q_OBJECT
 
@@ -28,6 +21,7 @@ class zUtils : public QObject {
     static bool getAutoNotificationSetting();
     static void textClipboardChanges(QSystemTrayIcon *trayIcon, QClipboard *clipboard);
     static void imageClipboardChanges(QSystemTrayIcon *trayIcon, QClipboard *clipboard);
+    static int hasPlatform();
     static int hasContentType(const QMimeData *mimeData);
     static Translate::LanguageType languageTypeCast(int value);
     static bool getLanguageSetting();

--- a/src/zUtils/zUtils.cc
+++ b/src/zUtils/zUtils.cc
@@ -11,14 +11,41 @@
 #include "../language/include/translate.hpp"
 
 using namespace zclipboard;
+using zclipboard::core::ContentType;
+using zclipboard::core::Platform;
 using zclipboard::language::Translate;
 
 QString zUtils::getCachePath() {
-#ifdef Q_OS_WIN
-    return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
-#else
-    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
-#endif
+    switch (hasPlatform()) {
+        case static_cast<int>(Platform::LINUX):
+            return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+
+        case static_cast<int>(Platform::MACOS):
+            return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+
+        case static_cast<int>(Platform::WINDOWS):
+            return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+
+        // Unknown operating system.
+        default:
+            return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    }
+}
+
+/*
+* Test from: tests/platform.
+*/
+int zUtils::hasPlatform() {
+    // clang-format off
+    #ifdef Q_OS_LINUX
+        return static_cast<int>(Platform::LINUX);
+    #elif Q_OS_DARWIN
+        return static_cast<int>(Platform::MACOS);
+    #elif Q_OS_WINDOWS
+        return static_cast<int>(Platform::WINDOWS);
+    #else
+        return static_cast<int>(Platform::UNKNOWN);
+    #endif
 }
 
 bool zUtils::getAutoHideSetting() {


### PR DESCRIPTION
* Migration **enum** `ContentType` -> to `enum.hpp` in `core` **namespace**.
* Add new **enum** `Platform` -> to `enum.hpp`.
* Add new `hasPlatform` **function** -> to `zUtils.hpp` to detection operating system platform.
* Refactor `getCachePath` to match platform, & return **cache path**. Default fallback is `cachePathLocation`.