### PR TITLE
Fix macro issue in MSVC, add new macro processor helper to Linux/Darwin

### DIFF
--- a/src/listener/include/ListenerDisconnect.hpp
+++ b/src/listener/include/ListenerDisconnect.hpp
@@ -5,15 +5,13 @@
 #include "../../zGui/include/getButton.hpp"
 #include "clearCacheListener.hpp"
 #include <QMainWindow>
-#define BUILD_CLASS(T, V) template<typename T, typename V>
-#define FORWARD(T, value) std::forward<T>(value)
-#define VOID_FUNC std::function<void()>
+#include "../../zUtils/include/macro.hpp"
 
 using zclipboard::lib_memory::PtrUnique;
 using zclipboard::zGui::GetButton;
 using zclipboard::lib_memory::MakePtr;
 
-namespace zclipboard::listener {
+LISTENER_NAMESPACE
     struct DisconnectImpl {
         QSettings *setting;
         GetButton *getButton;
@@ -31,7 +29,7 @@ namespace zclipboard::listener {
                 return this;
             }
 
-            BUILD_CLASS(T, V)
+            CLASS_BUILD(T, V)
             ListenerDisconnect *WithAndThen(T DisconnectImpl::*member, V &&value) {
                 Impl.get()->*member = FORWARD(V, value);
 
@@ -44,6 +42,6 @@ namespace zclipboard::listener {
 
             VOID_FUNC TryGetListener();
     };
-} // namespace zclipboard::listener
+END_NAMESPACE
 
 #endif // LISTENER_DISCONNECT_HPP

--- a/src/zGui/disconnectButton.cc
+++ b/src/zGui/disconnectButton.cc
@@ -3,6 +3,7 @@
 #include <QPushButton>
 #include <QMessageBox>
 #include <QStringLiteral>
+#include <QtGlobal>
 #include "../core/include/CoreDisconnect.hpp"
 #include "../zUtils/include/config.hpp"
 
@@ -10,9 +11,19 @@ using zclipboard::zGui::DisconnectButton;
 using zclipboard::listener::DisconnectImpl;
 
 void DisconnectButton::addDisconnectButton(QMainWindow *parent, GetButton *getButton, QGridLayout *layout) {
-    MAKE_SMART_PTR(QPushButton, disconnectButton);
-    MAKE_SMART_PTR(QSettings, settings, (AUTHOR_NAME, APP_NAME));
-    ADD_LAYOUT_TO(layout, disconnectButton.get(), 0, 4);
+    /*
+    * That macro only work in Linux/Darwin.
+    */
+    #if !defined (_WIN32)
+        MAKE_SMART_PTR(QPushButton, disconnectButton);
+        MAKE_SMART_PTR(QSettings, settings, (AUTHOR_NAME, APP_NAME));
+        ADD_LAYOUT_TO(layout, disconnectButton.get(), 0, 4);
+    #endif
+
+    disconnectButton = MakePtr<QPushButton>();
+    settings = MakePtr<QSettings>(AUTHOR_NAME, APP_NAME);
+    layout->addWidget(disconnectButton.get(), 0, 4);
+     
 
     const auto Function = BuilderFunc
         .   StartBuild()

--- a/src/zGui/disconnectButton.cc
+++ b/src/zGui/disconnectButton.cc
@@ -1,6 +1,5 @@
 #include "include/disconnectButton.hpp"
 #include "../listener/include/ListenerDisconnect.hpp"
-#include "../lib_memory/include/memory.hpp"
 #include <QPushButton>
 #include <QMessageBox>
 #include <QStringLiteral>
@@ -9,12 +8,11 @@
 
 using zclipboard::zGui::DisconnectButton;
 using zclipboard::listener::DisconnectImpl;
-using zclipboard::lib_memory::MakePtr;
 
 void DisconnectButton::addDisconnectButton(QMainWindow *parent, GetButton *getButton, QGridLayout *layout) {
-    disconnectButton = MakePtr<QPushButton>();
-    settings = MakePtr<QSettings>(AUTHOR_NAME, APP_NAME);
-    layout->addWidget(disconnectButton.get(), 0, 4);
+    MAKE_SMART_PTR(QPushButton, disconnectButton);
+    MAKE_SMART_PTR(QSettings, settings, (AUTHOR_NAME, APP_NAME));
+    ADD_LAYOUT_TO(layout, disconnectButton.get(), 0, 4);
 
     const auto Function = BuilderFunc
         .   StartBuild()

--- a/src/zGui/include/disconnectButton.hpp
+++ b/src/zGui/include/disconnectButton.hpp
@@ -7,25 +7,25 @@
 #include "getButton.hpp"
 #include "../../core/include/CoreDisconnect.hpp"
 #include "../../listener/include/ListenerDisconnect.hpp"
+#include "../../zUtils/include/macro.hpp"
 
 using zclipboard::zGui::GetButton;
 using zclipboard::lib_memory::PtrUnique;
 using zclipboard::core::CoreDisconnect;
 using zclipboard::listener::ListenerDisconnect;
 
-namespace zclipboard::zGui {
+GUI_NAMESPACE
+    class DisconnectButton {
+        private:
+            PtrUnique<QSettings> settings;
+            CoreDisconnect Builder;
+            ListenerDisconnect BuilderFunc;
+            PtrUnique<QPushButton> disconnectButton;
 
-class DisconnectButton {
-    private:
-        PtrUnique<QSettings> settings;
-        CoreDisconnect Builder;
-        ListenerDisconnect BuilderFunc;
-        PtrUnique<QPushButton> disconnectButton;
-
-    public:
-        void addDisconnectButton(QMainWindow *parent, GetButton *getButton, QGridLayout *layout);
-        QPushButton *getDisconnectButton();
-    };
-}  // namespace zclipboard::zGui
+        public:
+            void addDisconnectButton(QMainWindow *parent, GetButton *getButton, QGridLayout *layout);
+            QPushButton *getDisconnectButton();
+        };
+END_NAMESPACE
 
 #endif  // DISCONNECT_BUTTON_HPP

--- a/src/zUtils/include/macro.hpp
+++ b/src/zUtils/include/macro.hpp
@@ -1,0 +1,36 @@
+#ifndef UTILS_MACRO
+#define UTILS_MACRO
+
+#include "../../lib_memory/include/memory.hpp"
+
+using zclipboard::lib_memory::MakePtr;
+
+#define GET_PTR_MACRO(_1, _2, _3, NAME, ...) NAME
+#define MAKE_SMART_PTR(...) \
+        GET_PTR_MACRO(__VA_ARGS__, MAKE_SMART_PTR_IMPL_2, MAKE_SMART_PTR_IMPL_1)(__VA_ARGS__)
+
+#define ADD_LAYOUT_TO(layout, uiElement, row, column) layout->addWidget(uiElement, row, column)
+
+#define CLASS_BUILD(T, V) template<typename T, typename V>
+
+#define MAKE_SMART_PTR_IMPL_1(T, value) \
+        value = MakePtr<T>()
+
+#define MAKE_SMART_PTR_IMPL_2(T, value, ARGS) \
+        value = MakePtr<T> ARGS
+
+#define FORWARD(T, value) \
+        std::forward<T>(value)
+
+#define VOID_FUNC \
+        std::function<void()>
+
+#define LISTENER_NAMESPACE \
+        namespace zclipboard::listener { 
+
+#define GUI_NAMESPACE \
+        namespace zclipboard::zGui {
+
+#define END_NAMESPACE } 
+
+#endif // UTILS_MACRO


### PR DESCRIPTION
# Change log:
commit 35ebf0834e208297a881fd3f740a382a8ed5ac2a 
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sat Jul 12 12:50:58 2025 +0700

    Fix macro error in compiler step on Windows.

commit 35532d3d14a2da7e0d0708f1e9491b95115f100f
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sat Jul 12 12:26:30 2025 +0700

    - Removed unused macro
    - Removed namespace, use macro instead of.

commit 2cedd3de1f057718d6bd395a3f18f4f461e452f3
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sat Jul 12 12:26:19 2025 +0700

    - Removed unused include
    - Removed unused namespace
    - Use `MAKE_SMART_PTR` macro & `ADD_LAYOUT_TO` instead of.

commit 95f68cdb197e5fb7016a953b6c8dbb5423233828
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sat Jul 12 12:25:44 2025 +0700

    - Removed unused macro
    - Removed namespace, use macro instead

commit 21430c135825406604760436b40eb10840fa733a
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sat Jul 12 12:25:05 2025 +0700

    Add helper macro & namespace macro defined to project.