### PR TITLE
Refactor codebase & added new logging system for debugging.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,18 @@ if(LINUX)
     target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::LIBNOTIFY)
 endif()
 
-if(NOT WIN32)
-    target_link_libraries(${PROJECT_NAME} PRIVATE -lstdc++)
-endif()
 
+# We suggest use Clang for compiler.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(${PROJECT_NAME} PRIVATE "$<$<CXX_COMPILER_ID:Clang>:-fno-direct-access-external-data>")
+    # Warning:
+    # Only enable when use
+    # -DZ_DEBUG=1.
+    # We will disable it in default, for ABI mismatch reason.
+    if(Z_DEBUG)
+        add_compile_options(-stdlib=libc++)
+        target_link_libraries(${PROJECT_NAME} PRIVATE -lc++ -lc++abi)
+    endif()
 endif()
 
 message(STATUS "Current C Compiler: ${CMAKE_C_COMPILER}")

--- a/Source/GUI/Include/Window.hpp
+++ b/Source/GUI/Include/Window.hpp
@@ -35,6 +35,7 @@ using ZClipboard::Lib_Memory::PtrUnique;
 using ZClipboard::GUI::Hot_Reload::HotReloadLanguage;
 using ZClipboard::GUI::Hot_Reload::HotReloadImpl;
 using ZClipboard::GUI::Toolkit::ComponentsToolkit;
+using ZClipboard::AppUtils::Utils;
 
 GUI_NAMESPACE
 
@@ -81,6 +82,23 @@ GUI_NAMESPACE
         GetButton *getButton;
         SettingButton *settingButton;
         DisconnectButton *disconnectButton;
+
+        #if defined (Z_DEBUG)
+            private:
+                void __LOGGING_ALL_OBJECTS__() {
+                    using LogContext = ZClipboard::AppUtils::Utils::LogContext;
+
+                    LogContext{}.LogDebug(&Components_Tookit);
+                    LogContext{}.LogDebug(&tableView);
+                    LogContext{}.LogDebug(&searchArea);
+                    LogContext{}.LogDebug(&clearButton);
+                    LogContext{}.LogDebug(&getButton);
+                    LogContext{}.LogDebug(&settingButton);
+                    LogContext{}.LogDebug(&disconnectButton);
+                    LogContext{}.LogDebug(&systemTray);
+                    LogContext{}.LogDebug(&hotReloadLanguage);
+                }
+        #endif
     };
 
 END_NAMESPACE

--- a/Source/GUI/Window.cc
+++ b/Source/GUI/Window.cc
@@ -27,7 +27,6 @@ using ZClipboard::GUI::SystemTrayWidget;
 using ZClipboard::GUI::TableView;
 using ZClipboard::GUI::AppMainWindow;
 using ZClipboard::AppUtils::Utils;
-using LogContext = ZClipboard::AppUtils::Utils::LogContext;
 
 AppMainWindow::AppMainWindow(QWidget *zWindow) : QMainWindow(zWindow) {
     appIcon = QIcon(ICON_PATH);
@@ -47,8 +46,6 @@ AppMainWindow::AppMainWindow(QWidget *zWindow) : QMainWindow(zWindow) {
     translatorDectect();
 
     Utils::MakeSmartPtr<HotReloadLanguage>(hotReloadLanguage);
-    LogContext{}.LogDebug(&hotReloadLanguage);
-
     hotReloadLanguage
         ->  StartBuild()
         ->  WithAndThen(&HotReloadImpl::windowContext, this)
@@ -56,6 +53,10 @@ AppMainWindow::AppMainWindow(QWidget *zWindow) : QMainWindow(zWindow) {
         ->  ThenAddListener([this] {
             this->Translator();            
     });
+
+    #if defined (Z_DEBUG)
+        __LOGGING_ALL_OBJECTS__();
+    #endif
 }
 
 void AppMainWindow::InitiationObject() {
@@ -101,16 +102,6 @@ void AppMainWindow::SetupApplicationGUI() {
     notificationCore->onClipboardChanged(trayIcon, clipboard);
 
     connect(trayIcon, &QSystemTrayIcon::activated, this, &AppMainWindow::onTrayIconActivated);
-
-
-    LogContext{}.LogDebug(&Components_Tookit);
-    LogContext{}.LogDebug(&tableView);
-    LogContext{}.LogDebug(&searchArea);
-    LogContext{}.LogDebug(&clearButton);
-    LogContext{}.LogDebug(&getButton);
-    LogContext{}.LogDebug(&settingButton);
-    LogContext{}.LogDebug(&disconnectButton);
-    LogContext{}.LogDebug(&systemTray);
 }
 
 void AppMainWindow::closeEvent(QCloseEvent *event) {

--- a/Source/GUI/Window.cc
+++ b/Source/GUI/Window.cc
@@ -27,6 +27,7 @@ using ZClipboard::GUI::SystemTrayWidget;
 using ZClipboard::GUI::TableView;
 using ZClipboard::GUI::AppMainWindow;
 using ZClipboard::AppUtils::Utils;
+using LogContext = ZClipboard::AppUtils::Utils::LogContext;
 
 AppMainWindow::AppMainWindow(QWidget *zWindow) : QMainWindow(zWindow) {
     appIcon = QIcon(ICON_PATH);
@@ -46,7 +47,7 @@ AppMainWindow::AppMainWindow(QWidget *zWindow) : QMainWindow(zWindow) {
     translatorDectect();
 
     Utils::MakeSmartPtr<HotReloadLanguage>(hotReloadLanguage);
-    Utils::LogDebug("HotReloadLanguage address:", &hotReloadLanguage);
+    LogContext{}.LogDebug(&hotReloadLanguage);
 
     hotReloadLanguage
         ->  StartBuild()
@@ -102,14 +103,14 @@ void AppMainWindow::SetupApplicationGUI() {
     connect(trayIcon, &QSystemTrayIcon::activated, this, &AppMainWindow::onTrayIconActivated);
 
 
-    Utils::LogDebug("ComponentsTookit address:", &Components_Tookit);
-    Utils::LogDebug("TableView address:", &tableView);
-    Utils::LogDebug("SearchArea address:", &searchArea);
-    Utils::LogDebug("ClearButton address:", &clearButton);
-    Utils::LogDebug("GetButton address:", &getButton);
-    Utils::LogDebug("SettingButton address:", &settingButton);
-    Utils::LogDebug("DisconnectButton address:", &disconnectButton);
-    Utils::LogDebug("SystemTray address", &systemTray);
+    LogContext{}.LogDebug(&Components_Tookit);
+    LogContext{}.LogDebug(&tableView);
+    LogContext{}.LogDebug(&searchArea);
+    LogContext{}.LogDebug(&clearButton);
+    LogContext{}.LogDebug(&getButton);
+    LogContext{}.LogDebug(&settingButton);
+    LogContext{}.LogDebug(&disconnectButton);
+    LogContext{}.LogDebug(&systemTray);
 }
 
 void AppMainWindow::closeEvent(QCloseEvent *event) {

--- a/Source/Utils/Include/Utils.hpp
+++ b/Source/Utils/Include/Utils.hpp
@@ -13,11 +13,16 @@
 #include <QMimeData>
 #include <utility>
 
+#if defined(Z_DEBUG)
+    #include <source_location>
+#endif
+
 using ZClipboard::Core::ContentType;
 using ZClipboard::Core::Platform;
 using ZClipboard::Language::Translate;
 using ZClipboard::Lib_Memory::MakePtr;
 using std::forward;
+using std::string;
 
 UTILS_NAMESPACE
 
@@ -34,15 +39,23 @@ UTILS_NAMESPACE
         /*
         * Only for debug mode is enabled.
         */
-        template<typename... Args>
-        static void LogDebug(Args&&... args) {
-            #if defined (Z_DEBUG)
-                auto debugStream = qDebug();
-                debugStream << "[DEBUG_MODE]";
+        struct LogContext {
+            const std::source_location &location = std::source_location::current();
 
-                (debugStream << ... << args);
-            #endif
-        }
+            template<typename... Args>
+            void LogDebug(Args&&... args) {
+                #if defined (Z_DEBUG)
+                    auto debugStream = qDebug().noquote();
+
+                    debugStream << " [DEBUG_MODE] In File:" << location.file_name()<< "\n";
+                    debugStream << "[DEBUG_MODE] In Function:" << location.function_name() << "\n";
+                    debugStream << "[DEBUG_MODE] In Line:" << location.line() << "\n";
+                    debugStream << "[DEBUG_MODE] Address:";
+                    (debugStream << ... << args);
+                    debugStream << "\n";
+                #endif
+            }
+        };
 
         /*
         * Initiation a smart pointer.
@@ -51,14 +64,20 @@ UTILS_NAMESPACE
         static void MakeSmartPtr(V &&value, Args&&... args) {
             #if !defined (_WIN32)
 
-                MAKE_SMART_PTR(T, value, (std::forward<Args>(args)...));
-                
+                if(!value) {
+                    MAKE_SMART_PTR(T, value, (std::forward<Args>(args)...));
+                }
+
             #else
 
-                value = MakePtr<T>(std::forward<Args>(args)...);
+                if(!value) {
+                    value = MakePtr<T>(std::forward<Args>(args)...);
+                }
 
             #endif
         }
+
+        
     };
 
 END_NAMESPACE

--- a/Source/Utils/Include/Utils.hpp
+++ b/Source/Utils/Include/Utils.hpp
@@ -39,23 +39,23 @@ UTILS_NAMESPACE
         /*
         * Only for debug mode is enabled.
         */
-        struct LogContext {
-            const std::source_location &location = std::source_location::current();
+        #if defined(Z_DEBUG)
+            struct LogContext {
+                const std::source_location &location = std::source_location::current();
 
-            template<typename... Args>
-            void LogDebug(Args&&... args) {
-                #if defined (Z_DEBUG)
-                    auto debugStream = qDebug().noquote();
+                template<typename... Args>
+                void LogDebug(Args&&... args) {
+                        auto debugStream = qDebug().noquote();
 
-                    debugStream << " [DEBUG_MODE] In File:" << location.file_name()<< "\n";
-                    debugStream << "[DEBUG_MODE] In Function:" << location.function_name() << "\n";
-                    debugStream << "[DEBUG_MODE] In Line:" << location.line() << "\n";
-                    debugStream << "[DEBUG_MODE] Address:";
-                    (debugStream << ... << args);
-                    debugStream << "\n";
-                #endif
-            }
-        };
+                        debugStream << " [DEBUG_MODE] In File:" << location.file_name()<< "\n";
+                        debugStream << "[DEBUG_MODE] In Function:" << location.function_name() << "\n";
+                        debugStream << "[DEBUG_MODE] In Line:" << location.line() << "\n";
+                        debugStream << "[DEBUG_MODE] Address:";
+                        (debugStream << ... << args);
+                        debugStream << "\n";
+                }
+            };
+        #endif
 
         /*
         * Initiation a smart pointer.

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -28,23 +28,6 @@ debug_build() {
 
     cd "$build_dir" || exit 1
 
-    cmake -DCMAKE_BUILD_TYPE=Debug \
-        -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-        ..
-        
-    make
-    ./"$program_name"
-}
-
-normal_build() {
-     clang_detect
-     cmake_detect
-
-    cd "$build_dir" || exit 1
-
     cmake "$wall_flag" \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -52,6 +35,7 @@ normal_build() {
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DZ_DEBUG=1 \
         ..
+        
     make
     ./"$program_name"
 }
@@ -66,11 +50,7 @@ match_build() {
         mkdir "$build_dir"
     fi
     
-    case "$1" in
-    "debug") debug_build ;;
-    "") normal_build ;;
-    *) invalid_args "$1" ;;
-    esac
+    debug_build
 }
 
 os_detect() {


### PR DESCRIPTION
# Change log:
commit a7ae360bac337e0ed19a1655b5a3eb3ba6410357 
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Tue Jul 15 16:51:49 2025 +0700

    Defined & Implement helper function to logging all objects in class.

commit 6603fc731270311d2667158b55f291639222dfea
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Tue Jul 15 16:51:22 2025 +0700

    Fix: Implement new helper function to logging all objects address in program when debugging mode is enabled.

commit d040962aeaa9b598e584bdb2c7e0be8dddb42647
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Tue Jul 15 16:38:11 2025 +0700

    Fix error: "no type named 'source_location' in namespace 'std'" with `Z_DEBUG` macro.

commit 61d40d8d4e9a8fb888632c26c9622b98c6a94528
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Tue Jul 15 16:33:34 2025 +0700

    + Added include <source_location> for debugging mode only.
    + Defined new LogContext struct for logging. Can use only in debugging mode.

commit f1803510c0fea90543a5052c780225f6feaa28e3
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Tue Jul 15 16:32:24 2025 +0700

    + Implement new `LogDebug`, now use `LogContext{}.LogDebug` instead.

commit 1bb437d877623c69c19bd57104258dd85f9e8cbc
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Tue Jul 15 16:31:43 2025 +0700

    + Renamed `build.sh` to -> `debug.sh`, and removed `normal_build` option. Now can only run in `debug` mode.

commit 0b8865b63dd4748f473978cb2e52c2ee649c0575
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Tue Jul 15 16:31:06 2025 +0700

    + Added new feature for debugging only.