### PR TITLE
Fix: duplicate macro '__LOG__'

### DIFF
--- a/Source/GUI/Include/ClearButton.hpp
+++ b/Source/GUI/Include/ClearButton.hpp
@@ -41,8 +41,6 @@ GUI_NAMESPACE
 
         #if defined (Z_DEBUG)
             private:
-                #define __LOG__ __LOGGING_ALL_OBJECTS__();
-
                 void __LOGGING_ALL_OBJECTS__() {
                     LogContext{}.LogDebug(&BuilderCore);
                     LogContext{}.LogDebug(&BuilderFunc);

--- a/Source/GUI/Include/Window.hpp
+++ b/Source/GUI/Include/Window.hpp
@@ -91,8 +91,6 @@ GUI_NAMESPACE
 
         #if defined (Z_DEBUG)
             private:
-                #define __LOG__ __LOGGING_ALL_OBJECTS__();
-
                 void __LOGGING_ALL_OBJECTS__() {
                     LogContext{}.LogDebug(&Components_Tookit);
                     LogContext{}.LogDebug(&tableView);

--- a/Source/Utils/Include/Logging.hpp
+++ b/Source/Utils/Include/Logging.hpp
@@ -1,9 +1,22 @@
 #ifndef LOGGING_HPP
 #define LOGGING_HPP
+    #if !defined (Z_DEBUG)
+        #error "Cannot include 'Logging' because debug mode is disabled."
+    #endif
+
     #if defined(Z_DEBUG)
         #include "Namespace_Macro.hpp"
         #include <source_location>
         #include <QDebug>
+
+        /* This macro is only working if you already
+        *  defined the logging function '__LOGGING_ALL_OBJECTS()'
+        *  in your header file.
+        *  For security reason, please use it 
+        *  in debugging mode only.
+        */
+        #define __LOG__ __LOGGING_ALL_OBJECTS__();
+        
 
         UTILS_NAMESPACE
 


### PR DESCRIPTION
# Change log:
commit e4b6bd0c0e69569d4fe6e987fa9086275d945aa3 
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Wed Jul 16 16:09:12 2025 +0700

    + Defined new macro for debugging only: `__LOG__` and defined `#error` when `Logging.hpp` is included, but debugging mode is disabled.

commit 8f5b4059d8df08bfb56d6404ca0fe3e50c6f6145
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Wed Jul 16 16:08:12 2025 +0700

    - Removed private field macro `__LOG__` and use the macro `__LOG__` defined in `Logging.hpp`