### PR TITLE
Refactor & added type strict in compile-time for application.

### DIFF
--- a/Source/GUI/DisconnectButton.cc
+++ b/Source/GUI/DisconnectButton.cc
@@ -6,33 +6,44 @@
 #include "../Utils/Include/Config.hpp"
 #include "Include/GetConnectButton.hpp"
 
+#if defined (Z_DEBUG)
+    #include "../Utils/Include/AssertNullPtr.hpp"
+#endif
+
 using ZClipboard::Listener::DisconnectImpl;
 using ZClipboard::GUI::DisconnectButton;
 
-#define __SELF__ DisconnectButton
-#define __TOOKIT__ ComponentsToolkit
-#define __WINDOW__ QMainWindow
-#define __IMPL__ DisconnectImpl
+using Self = DisconnectButton;
+using Toolkit = ComponentsToolkit;
+using Window = QMainWindow;
+using Impl = DisconnectImpl;
 
-__SELF__ *__SELF__::UseConnectButton(GetButton *button) {
+Self *Self::UseConnectButton(GetButton *button) {
     this->getButton = button;
 
     return this;
 }
 
-void __SELF__::SetupDisconnectButton(__TOOKIT__ *toolkit, __WINDOW__ *window) {
+void Self::SetupDisconnectButton(Toolkit *toolkit, Window *window) {
     Utils::MakeSmartPtr<QSettings>(settings, AUTHOR_NAME, APP_NAME);
     auto disconnectButton = toolkit->GetDisconnectButton();
 
+    #if defined (Z_DEBUG)
+        AssertContext{}.RequireNonNullPtr(disconnectButton);
+        AssertContext{}.RequireNonNullPtr(settings.get());
+        AssertContext{}.RequireNonNullPtr(toolkit);
+        AssertContext{}.RequireNonNullPtr(window);
+        AssertContext{}.RequireNonNullPtr(getButton);
+    #endif
+
     const auto Function = BuilderFunc
         .   StartBuild()
-        ->  WithAndThen(&__IMPL__::setting, settings.get())
-        ->  WithAndThen(&__IMPL__::getButton, getButton)
-        ->  WithAndThen(&__IMPL__::toolkit, toolkit)
-        ->  WithAndThen(&__IMPL__::windowParent, window)
+        ->  WithAndThen(&Impl::setting, settings.get())
+        ->  WithAndThen(&Impl::getButton, getButton)
+        ->  WithAndThen(&Impl::toolkit, toolkit)
+        ->  WithAndThen(&Impl::windowParent, window)
         ->  WhenDone()
         ->  TryGetListener();
-
 
     Builder
         .   StartBuild(disconnectButton)

--- a/Source/Utils/Include/AssertNullPtr.hpp
+++ b/Source/Utils/Include/AssertNullPtr.hpp
@@ -1,0 +1,55 @@
+#ifndef ASSERT_NULL_PTR_HPP
+#define ASSERT_NULL_PTR_HPP
+
+#if !defined (Z_DEBUG)
+        #error "Could not include 'AssertNullPtr because 'DEBUG_MODE' is disabled.'"
+#endif
+
+#if defined (Z_DEBUG)
+
+    #include <type_traits>
+    #include <source_location>
+    #include "Logging.hpp"
+
+    using std::is_pointer;
+    using std::source_location;
+    using ZClipboard::AppUtils::LogContext;
+
+    struct AssertContext {
+        const source_location &location = source_location::current();
+
+        /*
+        * Detect the null pointer & stderr all information, like:
+        *
+        * Line number
+        *
+        * Function
+        *
+        * File
+        *
+        * Finally, abort the program.
+        *
+        * This function is required C++ version 20 or above,
+        * and the header `<source_location>` built-in.
+        */
+        template<typename T>
+        void RequireNonNullPtr(T ptr) {
+            if(!is_pointer<T>::value) {
+                /*
+                * Fatal & exit the program now.
+                * No-need return or do something.
+                */
+                LogContext{
+                    .location = location
+                }.Fatal("Could not check the value: ", ptr, " because it is not a pointer!");
+            }
+
+            LogContext{
+                .location = location
+            }.Fatal("Null-pointer detect, in address: ", ptr);
+        }
+    };
+
+#endif
+
+#endif // ASSERT_NULL_PTR_HPP

--- a/Source/Utils/Include/Logging.hpp
+++ b/Source/Utils/Include/Logging.hpp
@@ -12,7 +12,14 @@
 
         #include "Namespace_Macro.hpp"
         #include <source_location>
-        #include <QDebug>
+        #include <cstdlib>
+        #include <iostream>
+    
+        using std::cout;
+        using std::cerr;
+
+        #define DEBUG cout
+        #define ERROR cerr
 
         /* This macro is only working if you already
         *  defined the logging function '__LOGGING_ALL_OBJECTS()'
@@ -24,6 +31,10 @@
         
 
         UTILS_NAMESPACE
+            static inline const constexpr char RED[] = "\e[0;31m";
+            static inline const constexpr char GREEN[] = "\e[0;32m";
+            static inline const constexpr char WHITE[] = "\e[0;37m";
+            static inline const constexpr char YELLOW[] = "\e[0;33m";
 
             /*
             * Only for debug mode is enabled.
@@ -31,23 +42,48 @@
             struct LogContext {
                 const std::source_location &location = std::source_location::current();
 
+                /*
+                * Logging for debug & stdout all pointer address.
+                * Required C++ 20 or above.
+                */
                 template<typename... Args>
                 void LogDebug(Args&&... args) {
-                    auto debugStream = qDebug().noquote();
-
-                    debugStream << " [DEBUG_MODE] In File:" 
+                    DEBUG << " [DEBUG_MODE] In File:" 
                                 << location.file_name()<< "\n";
 
-                    debugStream << "[DEBUG_MODE] In Function:" 
+                    DEBUG << "[DEBUG_MODE] In Function:" 
                                 << location.function_name() << "\n";
 
-                    debugStream << "[DEBUG_MODE] In Line:" 
+                    DEBUG << "[DEBUG_MODE] In Line:" 
                                 << location.line() << "\n";
 
-                    debugStream << "[DEBUG_MODE] Address:";
+                    DEBUG << "[DEBUG_MODE] Address:";
 
-                    (debugStream << ... << args);
-                    debugStream << "\n";
+                    (DEBUG << ... << args);
+                    DEBUG << "\n";
+                }
+
+                /*
+                * Logging for case critical error
+                * & quit the program now.
+                * Required for C++ 20 or above.
+                */
+                template<typename... Args>
+                void Fatal(Args&&... args) {
+                    ERROR << RED << "[CRITICAL] In Function: "
+                                 << GREEN << location.function_name() << "\n";
+
+                    ERROR << RED << "[CRITICAL] In Line: "
+                                 << GREEN << location.line() << "\n";
+
+                    ERROR << RED << "[CRITICAL] In File: "
+                                 << GREEN << location.file_name() << "\n";
+                    
+                    ERROR << RED << "[CRITICAL] ";
+                    (ERROR << ... << (ERROR << YELLOW, args));
+                    ERROR << "\n";
+                    ERROR << WHITE; /* Reset to white, default of terminal. */
+                    std::abort();
                 }
             };
 

--- a/tests/nullptr_assert/CMakeLists.txt
+++ b/tests/nullptr_assert/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.19)
+project(nullptrassert)
+set(CMAKE_CXX_STANDARD 20)
+
+file(GLOB_RECURSE SOURCES_CXX "Source/*.cc")
+add_executable(${PROJECT_NAME} ${SOURCES_CXX})
+
+if(Z_DEBUG)
+    message(STATUS "Debug mode is enabled.")
+endif()
+
+if(Z_DEBUG)
+    add_compile_definitions(${PROJECT_NAME} PRIVATE Z_DEBUG)
+endif()
+
+# We suggest use Clang for compiler.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(${PROJECT_NAME} PRIVATE "$<$<CXX_COMPILER_ID:Clang>:-fno-direct-access-external-data>")
+    # Warning:
+    # Only enable when use
+    # -DZ_DEBUG=1.
+    # We will disable it in default, for ABI mismatch reason.
+    if(Z_DEBUG)
+        add_compile_options(-stdlib=libc++)
+        target_link_libraries(${PROJECT_NAME} PRIVATE -lc++ -lc++abi)
+    endif()
+endif()

--- a/tests/nullptr_assert/Source/main.cc
+++ b/tests/nullptr_assert/Source/main.cc
@@ -1,0 +1,13 @@
+#include "../../../Source/Utils/Include/AssertNullPtr.hpp"
+
+int main() {
+
+    int *myPtr;
+    int notPtrValue;
+    /*
+    * Will failed.
+    */
+    AssertContext{}.RequireNonNullPtr(myPtr);
+
+    return 0;
+}

--- a/tests/nullptr_assert/run.sh
+++ b/tests/nullptr_assert/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+function check_requirements() {
+    if ! command -v clang >/dev/null 2>&1; then
+        echo "Could not find Clang in your operating system"
+        exit 1
+    fi
+}
+
+function mkdir_build() {
+    local build_dir="build"
+
+    if [ ! -d "$build_dir" ]; then
+        echo "Could not find: '$build_dir' folder"
+        echo "Generating..."
+
+        mkdir -p "$build_dir"
+        echo "Successfully  create build dir: $build_dir"
+    fi
+}
+
+function build_test() {
+    local build_dir="build"
+    program_name="nullptrassert"
+
+    check_requirements
+    mkdir_build
+
+    cd "$build_dir" || exit 1
+    cmake -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DZ_DEBUG=1 \
+          ..
+    
+    make
+    ./$program_name
+}
+
+build_test


### PR DESCRIPTION
# Change Log:
commit d52471d2520fd27f54fb730d5708efa41e6780de (HEAD -> dev, origin/dev)
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Fri Jul 18 23:39:51 2025 +0700

    Added fail test case for `AssertContext`

commit af134afd71a32ec9ca03dafb7bf2f0360189c1b4
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Fri Jul 18 23:39:34 2025 +0700

    Added `CMakeLists.txt` for test is `AssertContext` working.

commit 5a014dcc9b3a1373ab65bd9b5efc8f198b050414
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Fri Jul 18 23:39:03 2025 +0700

    Added `run.sh` Bash script for run test automation.

commit 5738ca8d02b672fb91287737aa2d34675b830ce5
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Fri Jul 18 23:38:44 2025 +0700

    Removed `<QDebug>`, and use `<iostream` with macro wrap instead.

commit fdfb33a7cbaa3b4b637115c197eca2db398049a6
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Fri Jul 18 23:37:00 2025 +0700

    Added new header for assert pointer in compile-time. Only for debugging.

commit 93b08259ad41064a2666b9d1c9863d1ee19c6467
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Fri Jul 18 23:29:52 2025 +0700

    Added alias instead of macro.
    Added `AssertContext` in debugging mode for assert all pointer in function `SetupDisconnectButton`