### PR TITLE
Fix GUI display & implement `SettingWindow` GUI

### DIFF
--- a/Source/Core/CoreSettingWindow.cc
+++ b/Source/Core/CoreSettingWindow.cc
@@ -19,41 +19,31 @@ using Layout = QGridLayout;
     #include "../Utils/Include/Logging.hpp"
 
     using ZClipboard::AppUtils::LogContext;
+
+    using Log = LogContext;
+    using Assert = AssertContext;
 #endif 
 
 Self *Self::StartBuild() noexcept {
-    if(!Impl) {
-        Utils::MakeSmartPtr<DataImpl>(Impl);
-    }
+    Utils::MakeSmartPtr<DataImpl>(Impl);
 
     return this;
 }
 
-WindowComponents *Self::GetWindowComponents() noexcept {
-    if(!windowComponents) {
-        Utils::MakeSmartPtr<WindowComponents>(windowComponents);
-    }
-
-    return this
-        ->  windowComponents.get();
-}
-
-Window *Self::GetMainWindow() noexcept {
-    return  this
-        ->  Impl
-        ->  mainWindow;
-}
-
-Button *Self::GetSettingButton() noexcept{
-    return this
-        ->  Impl
-        ->  settingButton;
-}
 
 Layout *Self::GetLayout() noexcept {
     return this 
         ->  Impl
         ->  layout;
+}
+
+Self *Self::WithLayout(Layout *layout) {
+    this
+        ->  Impl
+        ->  layout
+        =   layout;
+
+    return this;
 }
 
 Self *Self::WhenDone() noexcept {
@@ -62,30 +52,28 @@ Self *Self::WhenDone() noexcept {
         using Log = LogContext;
 
         Assert{}.RequireNonNullPtr(Impl.get());
-        Assert{}.RequireNonNullPtr(Impl->mainWindow);
-        Assert{}.RequireNonNullPtr(Impl->settingButton);
 
         Log{}.LogDebug(Impl.get());
-        Log{}.LogDebug(Impl->mainWindow);
-        Log{}.LogDebug(Impl->settingButton);
     #endif
 
     return this;
 }
 
-void Self::Finally_Add_Listener() noexcept {
-    // const auto window = this->GetMainWindow();
-    const auto settingButton = this->GetSettingButton();
-    const auto windowComponents = this->GetWindowComponents();
-    const auto layout = this->GetLayout();
+void Self::SetupWindow(WindowComponents *components) noexcept {
+    auto layout = this->GetLayout();
 
+    Utils::MakeSmartPtr<LayoutManager>(layoutManager);
+        
+    #if defined (Z_DEBUG)
+        Assert{}.RequireNonNullPtr(layoutManager.get());
+        Assert{}.RequireNonNullPtr(components);
+        Assert{}.RequireNonNullPtr(layout);
+    #endif
+    
     using Impl = SettingWindowLayoutData;
-    if(!layoutManager) {
-        Utils::MakeSmartPtr<LayoutManager>(layoutManager);
-    }
     layoutManager
         ->  StartBuild()
-        ->  WithAndThen(&Impl::componentsManager, windowComponents)
+        ->  WithAndThen(&Impl::componentsManager, components)
         ->  WithAndThen(&Impl::layout, layout)
         ->  WhenDone()
         ->  SetupSettingWindowLayout();

--- a/Source/Core/Include/CoreSettingWindow.hpp
+++ b/Source/Core/Include/CoreSettingWindow.hpp
@@ -14,8 +14,6 @@ using ZClipboard::Lib_Memory::PtrUnique;
 CORE_NAMESPACE
 
     struct CoreSettingWindowData {
-        QPushButton *settingButton;
-        QMainWindow *mainWindow;
         QGridLayout *layout;
     };
 
@@ -30,28 +28,17 @@ CORE_NAMESPACE
             using Layout = QGridLayout;
  
         private:
-            PtrUnique<WindowComponents> windowComponents;
             PtrUnique<ImplData> Impl;
             PtrUnique<LayoutManager> layoutManager;
 
         private:
-            WindowComponents *GetWindowComponents() noexcept;
-            Window *GetMainWindow() noexcept;
-            Button *GetSettingButton() noexcept;
             Layout *GetLayout() noexcept;
 
         public:
             Self *StartBuild() noexcept;
-
-            CLASS_BUILD(T, V)
-            inline Self *WithAndThen(T ImplData::*member, V &&value) noexcept {
-                Impl.get()->*member = FORWARD(V, value);
-
-                return this;
-            }
-
+            Self *WithLayout(Layout *layout);
             Self *WhenDone() noexcept;
-            void Finally_Add_Listener() noexcept;
+            void SetupWindow(WindowComponents *components) noexcept;
     };
 
 END_NAMESPACE

--- a/Source/GUI/Include/SettingButton.hpp
+++ b/Source/GUI/Include/SettingButton.hpp
@@ -11,38 +11,44 @@
 #include <QComboBox>
 #include <QLabel>
 #include <QMainWindow>
-#include "../../Core/Include/CoreSetting.hpp"
 #include "../../Lib_Memory/Include/Memory.hpp"
 #include "../Toolkit/Include/MainWindow_Components.hpp"
-#include "../../Core/Include/CoreSettingWindow.hpp"
 #include "../../Utils/Include/Namespace_Macro.hpp"
+#include "../../GUI/Windows/Include/SettingWindow.hpp"
+#include "../../Listener/Include/ListenerOpenSettingWindow.hpp"
 
-using ZClipboard::Core::SettingCore;
 using ZClipboard::GUI::Toolkit::MainWindowComponentsManager;
+using ZClipboard::GUI::Windows::SettingWindowManager;
 using ZClipboard::Core::CoreSettingWindow;
+using ZClipboard::Listener::ListenerOpenSettingWindow;
 using ZClipboard::Lib_Memory::PtrUnique;
 
 GUI_NAMESPACE
 
-    struct SettingWidget {
-        QCheckBox *checkbox;
-        QDialog *dialog;
-        QSettings *settings;
-        QLabel *languageDescription;
-        QGridLayout *layout;
-        QComboBox *comboBox;
-    };
+    // struct SettingWidget {
+    //     QCheckBox *checkbox;
+    //     QDialog *dialog;
+    //     QSettings *settings;
+    //     QLabel *languageDescription;
+    //     QGridLayout *layout;
+    //     QComboBox *comboBox;
+    // };
 
     class SettingButton : public QObject {
         Q_OBJECT
 
     private:
         using Window = QMainWindow;
-        using MainWindowComponents = MainWindowComponentsManager;
+        using Components = MainWindowComponentsManager;
+        using Listener = ListenerOpenSettingWindow;
+        using Button = QPushButton;
+
+    private:
+        void SetupListener(Button *openSettingButton);
 
     public:
-        void SetupSettingButton(Window *window, MainWindowComponents *toolkit);
-        QPushButton *getSettingButton();
+        void SetupSettingButton(Window *window, Components *components);
+        // QPushButton *getSettingButton();
 
     private:
         // void showSettingDialog(QMainWindow *parent);
@@ -52,21 +58,20 @@ GUI_NAMESPACE
         // void addThemeSectionAction();
 
     private:
-        SettingCore *settingCore;
-        PtrUnique<QSettings> settings;
-        PtrUnique<QDialog> dialog;
-        PtrUnique<QGridLayout> layout;
-        PtrUnique<CoreSettingWindow> coreSettingWindow;
-        QPushButton *setPasswordButton;
+        // PtrUnique<QSettings> settings;
+        // PtrUnique<QDialog> dialog;
+        // PtrUnique<QGridLayout> layout;
+        PtrUnique<Listener> listener;
+        // QPushButton *setPasswordButton;
 
-        QLabel *languageDescription;
-        QLabel *themeDescription;
+        // QLabel *languageDescription;
+        // QLabel *themeDescription;
 
-        QComboBox *languageBox;
-        QComboBox *themeBox;
+        // QComboBox *languageBox;
+        // QComboBox *themeBox;
 
-        QCheckBox *autoHideCheckBox;
-        QCheckBox *autoNotificatonCheckBox;
+        // QCheckBox *autoHideCheckBox;
+        // QCheckBox *autoNotificatonCheckBox;
     };
     
 END_NAMESPACE

--- a/Source/GUI/SettingButton.cc
+++ b/Source/GUI/SettingButton.cc
@@ -1,56 +1,59 @@
 #include "Include/SettingButton.hpp"
 #include "../Language/Include/Translate.hpp"
 #include "Include/Window.hpp"
+#include "Windows/Include/SettingWindow.hpp"
 #include <QStringLiteral>
 #include <QSettings>
 #include <QIcon>
 
-using ZClipboard::Core::CoreSettingWindowData;
 using ZClipboard::Language::TransValue;
 using ZClipboard::GUI::SettingButton;
-using ZClipboard::AppUtils::Utils;
+
+using Button = QPushButton;
 
 #if defined (Z_DEBUG)
     #include "../Utils/Include/AssertNullPtr.hpp"
+    #include "../Utils/Include/Logging.hpp"
+
+    using ZClipboard::AppUtils::LogContext;
+
+    using Assert = AssertContext;
+    using Log = LogContext;
 #endif
 
+void SettingButton::SetupListener(Button *openSettingButton) {
+    listener = MakePtr<Listener>();
+
+    #if defined (Z_DEBUG)
+        Assert{}.RequireNonNullPtr(listener.get());
+        Assert{}.RequireNonNullPtr(openSettingButton);
+
+        Log{}.LogDebug(openSettingButton);
+        Log{}.LogDebug(listener.get());
+    #endif
+    
+    listener   
+        ->  StartBuild(openSettingButton)
+        ->  SetupListener();
+}
+
 void SettingButton::SetupSettingButton(
-                QMainWindow *window, MainWindowComponents *mainWindowComponents) {
+                QMainWindow *window, Components *mainWindowComponents) {
 
-    auto settingButton = mainWindowComponents->GetSettingButton();
-                
-    Utils::MakeSmartPtr<CoreSettingWindow>(coreSettingWindow);
-    Utils::MakeSmartPtr<QDialog>(dialog);
-    Utils::MakeSmartPtr<QGridLayout>(layout, dialog.get());
+    auto openSettingButton = mainWindowComponents->GetSettingButton();
 
-    // settingCore = new SettingCore();
+    // windowManager = MakePtr<SettingWindowManager>();
 
-    const auto function = [this, settingButton, window]() {
-        // window->hide();
-        // showSettingDialog(window);
+    // const auto function = [this, settingButton]() {
+    //     // window->hide();
+    //     // showSettingDialog(window);
 
-        #if defined (Z_DEBUG)
-            using Assert = AssertContext;
+    //     windowManager->ShowSettingWindow(settingButton);
+    // };
+    // function();
+    //connect(settingButton, &QPushButton::clicked, this, function);
 
-            Assert{}.RequireNonNullPtr(settingButton);
-            Assert{}.RequireNonNullPtr(layout.get());
-            Assert{}.RequireNonNullPtr(window);
-
-        #endif
-
-        using DataImpl = CoreSettingWindowData;
-        coreSettingWindow
-                    ->  StartBuild()
-                    ->  WithAndThen(&DataImpl::settingButton, settingButton)
-                    ->  WithAndThen(&DataImpl::layout, layout.get())
-                    ->  WithAndThen(&DataImpl::mainWindow, window)
-                    ->  Finally_Add_Listener();
-
-        dialog->exec();
-
-    };
-    connect(settingButton, &QPushButton::clicked, this, function);
-
+    this->SetupListener(openSettingButton);
 }
 
 // void SettingButton::showSettingDialog(QMainWindow *parent) {

--- a/Source/GUI/Windows/Include/SettingWindow.hpp
+++ b/Source/GUI/Windows/Include/SettingWindow.hpp
@@ -1,12 +1,31 @@
 #ifndef SETTING_WINDOW_HPP
 #define SETTING_WINDOW_HPP
 #include "../../../Utils/Include/Namespace_Macro.hpp"
+#include "../../../Core/Include/CoreSettingWindow.hpp"
+#include "../../../Lib_Memory/Include/Memory.hpp"
+#include <QPushButton>
+
+using ZClipboard::Core::CoreSettingWindow;
+using ZClipboard::Lib_Memory::PtrUnique;
+using ZClipboard::GUI::Toolkit::SettingWindowComponentsManager;
 
 GUI_WINDOW_NAMESPACE
 
     class SettingWindowManager {
+        private:
+            using CoreBuilder = CoreSettingWindow;
+            using Window = QDialog;
+            using Layout = QGridLayout;
+            using WindowComponents = SettingWindowComponentsManager;
+
+        private:
+            PtrUnique<CoreBuilder> coreBuilder;
+            PtrUnique<Window> settingWindow;
+            PtrUnique<Layout> windowLayout;
+            PtrUnique<WindowComponents> components;
+
         public:
-            void ShowSettingWindow();
+            void ShowSettingWindow(QPushButton *settingButton);
     };
 
 END_NAMESPACE

--- a/Source/GUI/Windows/SettingWindow.cc
+++ b/Source/GUI/Windows/SettingWindow.cc
@@ -1,6 +1,52 @@
 #include "Include/SettingWindow.hpp"
+#include "../../Utils/Include/Utils.hpp"
+#include <QDialog>
+#include <QGridLayout>
 
 using ZClipboard::GUI::Windows::SettingWindowManager;
-using Self = SettingWindowManager;
+using ZClipboard::Core::CoreSettingWindowData;
+using ZClipboard::AppUtils::Utils;
 
-void Self::ShowSettingWindow() {}
+using Self = SettingWindowManager;
+using Window = QDialog;
+using Layout = QGridLayout;
+using Button = QPushButton;
+
+#if defined (Z_DEBUG)
+    #include "../../Utils/Include/AssertNullPtr.hpp"
+    #include "../../Utils/Include/Logging.hpp"
+
+    using ZClipboard::AppUtils::LogContext;
+
+    using Log = LogContext;
+    using Assert = AssertContext;
+#endif
+
+void Self::ShowSettingWindow(Button *settingButton) {
+    Utils::MakeSmartPtr<Window>(settingWindow);
+    Utils::MakeSmartPtr<Layout>(windowLayout, settingWindow.get());
+    Utils::MakeSmartPtr<CoreBuilder>(coreBuilder);
+    Utils::MakeSmartPtr<WindowComponents>(components);
+
+    #if defined (Z_DEBUG)
+        Assert{}.RequireNonNullPtr(coreBuilder.get());
+        Assert{}.RequireNonNullPtr(settingWindow.get());
+        Assert{}.RequireNonNullPtr(windowLayout.get());
+        Assert{}.RequireNonNullPtr(components.get());
+
+        Log{}.LogDebug(settingWindow.get());
+        Log{}.LogDebug(windowLayout.get());
+        Log{}.LogDebug(coreBuilder.get());
+        Log{}.LogDebug(components.get());
+    #endif 
+
+    using Impl = CoreSettingWindowData;
+    coreBuilder
+        ->  StartBuild()
+        ->  WithLayout(windowLayout.get())
+        ->  WhenDone()
+        ->  SetupWindow(components.get());
+
+    settingWindow->setMinimumSize(400, 400);
+    settingWindow->show();
+}

--- a/Source/Listener/Include/ListenerOpenSettingWindow.hpp
+++ b/Source/Listener/Include/ListenerOpenSettingWindow.hpp
@@ -1,0 +1,27 @@
+#ifndef LISTENER_OPEN_SETTING_WINDOW_HPP
+#define LISTENER_OPEN_SETTING_WINDOW_HPP
+#include "../../Utils/Include/Namespace_Macro.hpp"
+#include "../../GUI/Windows/Include/SettingWindow.hpp"
+
+using ZClipboard::GUI::Windows::SettingWindowManager;
+
+LISTENER_NAMESPACE
+
+    class ListenerOpenSettingWindow {
+        private:
+            using WindowManager = SettingWindowManager;
+            using Self = ListenerOpenSettingWindow;
+            using Button = QPushButton;
+
+        private:
+            PtrUnique<WindowManager> windowManager;
+            Button *settingButton;
+
+        public:
+            Self *StartBuild(Button *settingButton);
+            void SetupListener();
+    };
+
+END_NAMESPACE
+
+#endif // LISTENER_OPEN_SETTING_WINDOW_HPP

--- a/Source/Listener/ListenerOpenSettingWindow.cc
+++ b/Source/Listener/ListenerOpenSettingWindow.cc
@@ -1,0 +1,48 @@
+#include "Include/ListenerOpenSettingWindow.hpp"
+#include "../Utils/Include/Utils.hpp"
+
+using ZClipboard::Listener::ListenerOpenSettingWindow;
+using ZClipboard::AppUtils::Utils;
+using Self = ListenerOpenSettingWindow;
+
+#if defined (Z_DEBUG)
+    #include "../Utils/Include/AssertNullPtr.hpp"
+    #include "../Utils/Include/Logging.hpp"
+
+    using ZClipboard::AppUtils::LogContext;
+
+    using Assert = AssertContext;
+    using Log = LogContext;
+#endif 
+
+Self *Self::StartBuild(Button *settingButton) {
+    this->settingButton = settingButton;
+
+    #if defined (Z_DEBUG)
+        //Assert{}.RequireNonNullPtr(windowManager.get());
+        Assert{}.RequireNonNullPtr(settingButton);
+
+        //Log{}.LogDebug(windowManager.get());
+        Log{}.LogDebug(settingButton);
+    #endif
+
+    return this;
+}
+
+void Self::SetupListener() {    
+    const auto Fn = [this]{
+        Utils::MakeSmartPtr<WindowManager>(windowManager);
+        
+        #if defined (Z_DEBUG)
+            Assert{}.RequireNonNullPtr(windowManager.get());
+            Assert{}.RequireNonNullPtr(this->settingButton);
+
+            Log{}.LogDebug(windowManager.get());
+            Log{}.LogDebug(this->settingButton);
+        #endif
+
+        windowManager->ShowSettingWindow(this->settingButton);
+    };
+
+    QObject::connect(this->settingButton, &QPushButton::clicked, Fn);
+}

--- a/Source/Utils/Include/Logging.hpp
+++ b/Source/Utils/Include/Logging.hpp
@@ -69,8 +69,9 @@
                     DEBUG << Ascii_Color::GREEN << "[DEBUG_MODE] Address: ";
 
                     (DEBUG << ... << (DEBUG << Ascii_Color::YELLOW, args));
-                    DEBUG << "\n";
                     DEBUG << Ascii_Color::WHITE; /* Reset to white, default of terminal. */
+                    DEBUG << "\n";
+              
                 }
 
                 /*


### PR DESCRIPTION
# Change Log:
commit 9b10ee678c848e0911d395d80097e637ef7cf574 (HEAD -> dev, origin/dev)
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:45:04 2025 +0700

    Fix: Reset color to default terminal color (`white`) to `LogDebug`

commit ef94445c7ce674262e57200460e63b451b6c6b27
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:44:24 2025 +0700

    feat:
    Defined `Listener` for action `click` to `QPushButton` `SettingButton`

commit 16d98c4ff889a502b2dc9706b0d894e6648f2bff
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:44:11 2025 +0700

    feat:
    Implement `Listener` for action `click` to `QPushButton` `SettingButton`

commit 5701d03f3a88f59f2837652fd78d7b11d8c3e574
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:43:26 2025 +0700

    feat:
    Added new private member field for class `SettingWindowManager` & `using` types alias

commit 1b6064bbe1860b8f27da24b860d496fc4fdbc7cf
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:41:54 2025 +0700

    feat:
    Implement GUI for `SettingWindow` when clicked to `QPushButton` `SettingButton`

commit d56298f37386fe131365a7454dc182e7382ff098
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:40:48 2025 +0700

    feat:
    Removed old-deprecated include & using class/struct
    Commented old-deprecated struct data `SettingWidget` & private field member in class `SettingButton`
    Added new private method `SetupSettingButton`, with one parameter `Button (QPushButton type alias) *openSettingButton`

commit 4974d6674a89114e8e8883fbe2971b6aa74b3ff9
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:37:31 2025 +0700

    feat:
    Removed unused type using alias `Button = QPushButton`
    Added include in the `Z_DEBUG` macro scope
    Removed & commented deprecated methods.

commit b19e2bd74f21268fb7b699dae7bc2bc7e175ad82
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:33:09 2025 +0700

    feat: Removed `*settingButton` with type `QPushButton` and `*mainWindow` with type `QMainWindow` in `CoreSettingWindowData` struct.
    Removed field `windowComponent` with type `WindowComponent` in class `CoreSettingWindow`.
    Removed two `getter` methods in same class, as `*GetMainWindow` and `*GetSettingButton` (Type is: `Window` & `Button`, as types alias defined in same header file)

commit 724564210a035a5363290b6b2163b1ebeaf44b00
Author: Reim-developer <contact.kaxtr@gmail.com>
Date:   Sun Jul 27 05:27:58 2025 +0700

    feat: removed `WithLayout` function, added new `Assert Context` to `Z_DEBUG` scope. Renamed function name signature `Finnally_Add_Listener` -> `SetupWindow`, and added function parameter `*components` with using type alias `WindowsComponent` (defined in `CoreSettingWindow.hpp`).